### PR TITLE
Update for the latest changes to cinder/glnext and Oculus SDK 0.4.4

### DIFF
--- a/samples/BasicOculus/src/BasicOculusApp.cpp
+++ b/samples/BasicOculus/src/BasicOculusApp.cpp
@@ -34,7 +34,7 @@
 *
 */
 
-#include "cinder/app/AppNative.h"
+#include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 #include "cinder/Camera.h"
 #include "cinder/gl/Shader.h"
@@ -48,14 +48,13 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
-class BasicOculusApp : public AppNative {
+class BasicOculusApp : public App {
 public:
 	virtual void	setup();
 	virtual void	update();
 	virtual void	draw();
 	
 	void keyDown(KeyEvent event);
-	void			prepareSettings(Settings* settings);
 
 	RiftRef				mRift;
 	bool				mRiftSwap;
@@ -70,19 +69,14 @@ public:
 
 const int SKY_BOX_SIZE = 500;
 
-void BasicOculusApp::prepareSettings(Settings* settings)
-{
-	settings->disableFrameRate();
-	mRift = Rift::create(false);
-//    mRift->disableCaps(ovrHmdCap_ExtendDesktop);
-	settings->setWindowSize(mRift->getHMDRes());
-	settings->setWindowPos(mRift->getHMDDesktopPos()+ivec2(10,10));
-	console() << "native res " << mRift->getHMDDesktopPos() << endl;
-}
-
-
 void BasicOculusApp::setup()
 {
+	mRift = Rift::create(false);
+//    mRift->disableCaps(ovrHmdCap_ExtendDesktop);
+	setWindowSize(mRift->getHMDRes());
+	setWindowPos(mRift->getHMDDesktopPos()+ivec2(10,10));
+	console() << "native res " << mRift->getHMDRes() << endl;
+
 	if (mRift->getDirectMode())
 		mRift->attachToMonitor(app::getWindow()->getNative());
 	mRift->enableCaps(ovrHmdCap_LowPersistence);
@@ -97,7 +91,7 @@ void BasicOculusApp::setup()
 	
 	//setup rift. let rift swap buffers
 	mRiftSwap = true;
-	mCubeMap = gl::TextureCubeMap::createHorizontalCross(loadImage(loadAsset("env_map.jpg")), gl::TextureCubeMap::Format().mipmap());
+	mCubeMap = gl::TextureCubeMap::create(loadImage(loadAsset("env_map.jpg")), gl::TextureCubeMap::Format().mipmap());
 
 #if defined( CINDER_GL_ES )
 	auto envMapGlsl = gl::GlslProg::create(loadAsset("env_map_es2.vert"), loadAsset("env_map_es2.frag"));
@@ -175,4 +169,6 @@ void BasicOculusApp::draw()
 
 }
 
-CINDER_APP_NATIVE(BasicOculusApp, RendererGl)
+CINDER_APP(BasicOculusApp, RendererGl, [](App::Settings* settings){
+	settings->disableFrameRate();
+})

--- a/samples/BasicOculus/xcode/BasicOculus_Prefix.pch
+++ b/samples/BasicOculus/xcode/BasicOculus_Prefix.pch
@@ -5,8 +5,6 @@
 #if defined( __cplusplus )
 	#include "cinder/Cinder.h"
 	
-	#include "cinder/app/AppBasic.h"
-	
 	#include "cinder/gl/gl.h"
 	
 	#include "cinder/CinderMath.h"

--- a/src/OculusCinder.cpp
+++ b/src/OculusCinder.cpp
@@ -35,7 +35,7 @@
 */
 
 #include "OculusCinder.h"
-#include "cinder/app/AppBasic.h"
+#include "cinder/app/App.h"
 
 using namespace ci;
 using namespace ci::app;
@@ -118,7 +118,7 @@ void Rift::initGL()
 	ovrGLConfig cfg;
 	memset(&cfg, 0, sizeof(cfg));
 	cfg.OGL.Header.API = ovrRenderAPI_OpenGL;
-		cfg.OGL.Header.RTSize = Rift::toOvr(glm::uvec2(ci::app::getWindowIndex(0)->getWidth(), ci::app::getWindowIndex(0)->getHeight()));
+		cfg.OGL.Header.BackBufferSize = Rift::toOvr(glm::uvec2(ci::app::getWindowIndex(0)->getWidth(), ci::app::getWindowIndex(0)->getHeight()));
 	cfg.OGL.Header.Multisample = 1;
 
 	void* windowHandle = ci::app::getWindowIndex(0)->getNative();


### PR DESCRIPTION
Don't merge this yet.

I made a few changes to get this compiling with the latest cinder/glnext and Oculus SDK 0.4.4. The sample compiles and runs now, but it doesn't seem to render anything after the initial frame. Nothing drawn in `Rift::draw()` is actually displayed. I'll keep hacking on it, but check out this branch if you get the chance.

**List of changes:**
- Inhertit from App vs AppNative
- Use the new TextureCubeMap::create()
  - see: https://forum.libcinder.org/#Topic/23286000002268033
- Move prepareSettings to the CINDER_APP macro
  - see: https://forum.libcinder.org/#Topic/23286000002275025
- Rename RTSize to BackBufferSize as per the latest Oculus SDK
